### PR TITLE
Update out-of-date napari roadmap link

### DIFF
--- a/lectures/4_discussion_session.ipynb
+++ b/lectures/4_discussion_session.ipynb
@@ -2,32 +2,32 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# discussion"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We will use this time for some free discussion about napari, scikit-image, and scientific Python more generally. Possible topics:\n",
     "\n",
-    "- The napari [0.4 roadmap](https://github.com/napari/napari/pull/1906)\n",
+    "- The [napari roadmap](https://napari.org/roadmaps/index.html)\n",
     "- building UIs with magicgui\n",
     "- embedding matplotlib widgets and adding interactivity with matplotlib (e.g. [mass spec imaging](https://twitter.com/jnuneziglesias/status/1286599143008346112) or [napariboard](https://github.com/jni/napariboard-proto))\n",
     "- creating and using IO plugins\n",
     "- next generation file formats and napari\n",
     "- contributing to open source\n",
     "- any issues you've had using skimage or napari with your own data"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
I've replaced the out-of-date link with https://napari.org/roadmaps/index.html which should always stay current.