### PR TITLE
Remove dask statement where I'm not confident about its accuracy

### DIFF
--- a/lectures/3_dask.ipynb
+++ b/lectures/3_dask.ipynb
@@ -29,7 +29,6 @@
     "\n",
     "A first life hack: in general, avoid using bare dask, and instead create a `dask.distributed` Client as in the cell below. What this buys you:\n",
     "\n",
-    "- memory management: the distributed scheduler that is automatically created with the default client will launch processes with maximum memory limits. If they exceed those limits, the scheduler will stop sending tasks to them and eventually kill them. In contrast, without `distributed`, you are subject to the same issues as bare Python. It is very easy to freeze your machine.\n",
     "- a [diagnostics dashboard](https://docs.dask.org/en/latest/diagnostics-distributed.html). This can be invaluable in helping to understand performance in your application. We'll see a live example below.\n",
     "- seamless scaling. Whether the scheduler is using local workers or connected to [your institution's HPC](https://jobqueue.dask.org/en/latest/), or [cloud compute](https://docs.dask.org/en/latest/setup/cloud.html), the API is the same — you just change the scheduler and connect the Client to it."
    ]
@@ -480,7 +479,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes https://github.com/jni/lma-2021-bioimage-analysis-python/issues/3

We had a discussion about whether "It handles data locality with more sophistication, and so can be more efficient than the multiprocessing scheduler on workloads that require multiple processes" [ref](https://docs.dask.org/en/latest/scheduling.html) was equivalent to the statement made in the notebook, but I'm not entirely convinced the way we have explained it is accurate.

So, I'm going to leave it out for now.